### PR TITLE
fix: escape webhook handler HTML outputs and handle optional secops import

### DIFF
--- a/agent_soc_manager/tools/chatops/webhook_handler.py
+++ b/agent_soc_manager/tools/chatops/webhook_handler.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import os
 
@@ -36,6 +37,10 @@ async def handle_action(t: str = Query(..., description="Signed action token")):
             "No action was executed.</p></body></html>",
             status_code=503,
         )
+    action = None
+    session_id = None
+    agent_engine_id = None
+    user_id = None
     try:
         # 1. Verify and decode payload
         payload = verify_signed_payload(t)
@@ -100,7 +105,7 @@ async def handle_action(t: str = Query(..., description="Signed action token")):
                 <div class="card">
                     <div class="icon">OK</div>
                     <h1>Action Confirmed</h1>
-                    <p>The action <b>{action}</b> has been successfully processed by the AI Agent.</p>
+                    <p>The action <b>{html.escape(str(action))}</b> has been successfully processed by the AI Agent.</p>
                     <p>You can close this tab and return to Google Chat.</p>
                 </div>
             </body>
@@ -112,10 +117,13 @@ async def handle_action(t: str = Query(..., description="Signed action token")):
         # Debugging information to help identify the 400 error
         # Ensure IDs are strings and strip any quotes if they exist in the value
         agent_engine_id_str = (
-            str(agent_engine_id).strip("\"'") if agent_engine_id else "N/A"
+            html.escape(str(agent_engine_id).strip("\"'")) if agent_engine_id else "N/A"
         )
-        session_id_str = str(session_id).strip("\"'") if session_id else "N/A"
-        user_id_str = str(user_id).strip("\"'") if user_id else "N/A"
+        session_id_str = (
+            html.escape(str(session_id).strip("\"'")) if session_id else "N/A"
+        )
+        user_id_str = html.escape(str(user_id).strip("\"'")) if user_id else "N/A"
+        error_msg = html.escape(str(e))
 
         debug_info = f"""
         <div style="background: #f8f9fa; border: 1px solid #dee2e6; padding: 15px; border-radius: 5px; text-align: left; margin-top: 20px;">
@@ -124,7 +132,7 @@ async def handle_action(t: str = Query(..., description="Signed action token")):
                 <li>Agent ID: "{agent_engine_id_str}"</li>
                 <li>Session ID: "{session_id_str}"</li>
                 <li>User ID: "{user_id_str}"</li>
-                <li>Error: {str(e)}</li>
+                <li>Error: {error_msg}</li>
             </ul>
         </div>
         """
@@ -133,7 +141,7 @@ async def handle_action(t: str = Query(..., description="Signed action token")):
             <html>
                 <body style="font-family: Arial; text-align: center; padding-top: 50px;">
                     <h1 style="color: #d93025;">Action Failed</h1>
-                    <p>There was an error processing your request: {str(e)}</p>
+                    <p>There was an error processing your request: {error_msg}</p>
                     {debug_info}
                     <p>Check the Cloud Run logs for more details.</p>
                 </body>

--- a/installation_scripts/harvest_investigations.py
+++ b/installation_scripts/harvest_investigations.py
@@ -11,6 +11,8 @@ import typer
 from dotenv import load_dotenv
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
+
+
 try:
     from secops import SecOpsClient
 except ImportError:

--- a/installation_scripts/harvest_investigations.py
+++ b/installation_scripts/harvest_investigations.py
@@ -11,7 +11,10 @@ import typer
 from dotenv import load_dotenv
 from google.auth.transport.requests import Request
 from google.oauth2 import service_account
-from secops import SecOpsClient
+try:
+    from secops import SecOpsClient
+except ImportError:
+    SecOpsClient = None
 
 
 load_dotenv()


### PR DESCRIPTION
## Summary

- Sanitize dynamic outputs and error details with `html.escape` in ChatOps webhook responses to mitigate potential XSS vulnerabilities.
- Pre-initialize action, session, agent engine, and user ID variables in `webhook_handler.py` to prevent potential unbound variable errors during exception handling.
- Gracefully handle `ImportError` when importing `SecOpsClient` in `harvest_investigations.py` for environments where the `secops` package is not present.

## Changes

### 1. ChatOps Webhook Handler (`agent_soc_manager/tools/chatops/webhook_handler.py`)
- Added `import html`.
- Pre-initialized `action = None`, `session_id = None`, `agent_engine_id = None`, and `user_id = None` ahead of the try block.
- Applied `html.escape()` on `action` in the confirmation HTML payload.
- Applied `html.escape()` on `agent_engine_id_str`, `session_id_str`, `user_id_str`, and `error_msg` rendered into the error page and debug card.

### 2. Chronicle Investigation Harvester (`installation_scripts/harvest_investigations.py`)
- Wrapped `from secops import SecOpsClient` in `try...except ImportError` fallback setting `SecOpsClient = None`.

## Security Verification

- Verified no secrets or credentials committed.
- Validated Python syntax with `py_compile`.
- Validated git diff whitespace checks.

TAG=agy
CONV=276c2887-4f12-493e-b8a5-b75413b47c40