### PR TITLE
ci: align pre-commit hooks and GitHub Actions code quality checks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,10 +46,7 @@ jobs:
 
       - name: Run pre-commit hooks
         run: |
-          # Run without modifying files (check mode only for CI)
-          SKIP=ruff pre-commit run --all-files --show-diff-on-failure
-          # Run ruff separately in check mode (no --fix)
-          ruff check .
+          pre-commit run --all-files --show-diff-on-failure
 
   # NOTE: Additional jobs (type-check, security, tests) are disabled in this PR
   # They will be re-enabled after fixing existing issues in separate PRs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
       - id: ruff
         name: ruff
         description: Run ruff linter (replaces isort, bandit, flake8)
-        args: ['--fix']
 
   - repo: https://github.com/google/pyink
     rev: '24.10.1'

--- a/installation_scripts/print_help.py
+++ b/installation_scripts/print_help.py
@@ -65,6 +65,7 @@ GROUPS = {
         "clean",
         "lint",
         "format",
+        "pre-commit",
         "check-env",
         "check-prereqs",
         "check-deploy",

--- a/justfile
+++ b/justfile
@@ -888,6 +888,18 @@ format:
         echo "No formatter available (install ruff or black)"
     fi
 
+# Run pre-commit hooks across all files
+pre-commit:
+    #!/usr/bin/env bash
+    if command -v pre-commit >/dev/null 2>&1; then
+        pre-commit run --all-files
+    elif command -v uvx >/dev/null 2>&1; then
+        uvx pre-commit run --all-files
+    else
+        echo "Error: Neither pre-commit nor uvx is available"
+        exit 1
+    fi
+
 # Harvest and enrich investigations and detections from Chronicle SIEM
 harvest: harvest-investigations harvest-detections
 


### PR DESCRIPTION
## Summary

- Remove `--fix` argument from the `ruff` hook in `.pre-commit-config.yaml` so local pre-commit runs ruff in strict check mode.
- Align GitHub Actions CI in `code-quality.yml` by replacing the `SKIP=ruff` workaround and redundant `ruff check .` with a direct `pre-commit run --all-files --show-diff-on-failure`.
- Add a `pre-commit` recipe to `justfile` and categorize it under "Setup & Environment" in `installation_scripts/print_help.py`.

## Changes

### 1. Pre-commit Configuration (`.pre-commit-config.yaml`)
- Removed `args: ['--fix']` from the `ruff` hook so both `ruff` and `pyink` run in standard check mode when executing pre-commit.

### 2. GitHub Actions Workflow (`.github/workflows/code-quality.yml`)
- Simplified the `Run pre-commit hooks` step to execute `pre-commit run --all-files --show-diff-on-failure` directly without skipping `ruff`.

### 3. Justfile & CLI (`justfile`, `installation_scripts/print_help.py`)
- Added `just pre-commit` recipe with fallback from local `pre-commit` to `uvx pre-commit`.
- Categorized `pre-commit` in `GROUPS["Setup & Environment"]` in `print_help.py`.

## Verification

- Ran `just pre-commit` locally; all 8 hooks passed with zero errors.
- Ran `uvx ruff check .` across the repository; passed with zero errors.
- Checked `git diff --check`; clean.

TAG=agy
CONV=276c2887-4f12-493e-b8a5-b75413b47c40